### PR TITLE
recordfail_timeout takes an integer, not a string

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ This module manages GRUB 2 bootloader
 ####  recordfail_timeout
 - Set default timeout value for GRUB2.
   Useful to stop headless machines stalling during boot.
-- **STRING** : *Empty by default*
+- **INTEGER** : *Empty by default*
 
 ####  serial_command
 - Set settings for the serial console

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -67,7 +67,7 @@
 # [*recordfail_timeout*]
 #   Set default timeout value for GRUB2.
 #   Without this set, headless machines may stall during boot.
-#   STRING : undef
+#   INTEGER : undef
 #
 # [*serial_command*]
 #   Set settings for the serial console


### PR DESCRIPTION
Fixes this in documentation.